### PR TITLE
fix startup problem

### DIFF
--- a/lua/nvim-picgo/init.lua
+++ b/lua/nvim-picgo/init.lua
@@ -61,8 +61,7 @@ local function callbackfn(job_id, data, _)
 end
 
 function nvim_picgo.setup(conf)
-    local result = vim.fn.system("picgo -v")
-    if not result:match("^%d") then
+    if vim.fn.executable("picgo") ~= 1 then
         vim.api.nvim_echo({ { "Missing picgo-core dependencies", "ErrorMsg" } }, true, {})
         return
     end


### PR DESCRIPTION
Using `vim.fn.system` and match methods to check `picgo` is very slow.
If just check `picgo` is executable, `vim.fn.executable` is more efficient.

Using return code `~=1` to process check action. 
